### PR TITLE
Uniformise style for gallery pages

### DIFF
--- a/Productions/DM Page de garde/Classe-1/Page-garde-classe-1.html
+++ b/Productions/DM Page de garde/Classe-1/Page-garde-classe-1.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Productions des élèves - Classe 1</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="../../../styles.css">
 </head>
 <body>
     <div class="container">

--- a/Productions/DM Page de garde/Classe-1/styles.css
+++ b/Productions/DM Page de garde/Classe-1/styles.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&family=Style+Script&display=swap');
 
 * {
     margin: 0;
@@ -8,31 +8,36 @@
 
 body {
     font-family: 'Roboto', sans-serif;
-    background-color: #f4f4f4;
-    padding: 20px;
+    margin: 0;
+    padding: 0;
+    background: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('../../../Images/background.webp');
+    background-size: cover;
+    background-attachment: fixed;
+    background-repeat: no-repeat;
+    color: #fff;
 }
 
 .container {
     max-width: 1200px;
     margin: 0 auto;
     padding: 20px;
-    background-color: #fff;
+    background: rgba(0, 102, 51, 0.5);
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
 h1 {
     text-align: center;
     margin-bottom: 10px;
-    color: #333;
-    font-family: 'Open Sans', sans-serif;
-    font-size: 2em;
+    color: #fff;
+    font-family: 'Style Script', cursive;
+    font-size: 2.5em;
 }
 
 .instruction {
     text-align: center;
     margin-bottom: 30px;
     font-size: 1.3em;
-    color: #555;
+    color: #fff;
     font-family: 'Open Sans', sans-serif;
 }
 

--- a/Productions/DM Page de garde/Classe-2/Page-garde-classe-2.html
+++ b/Productions/DM Page de garde/Classe-2/Page-garde-classe-2.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Productions des élèves - Classe 2</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="../../../styles.css">
 </head>
 <body>
     <div class="container">

--- a/Productions/DM Page de garde/Classe-2/styles.css
+++ b/Productions/DM Page de garde/Classe-2/styles.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&family=Style+Script&display=swap');
 
 * {
     margin: 0;
@@ -8,31 +8,36 @@
 
 body {
     font-family: 'Roboto', sans-serif;
-    background-color: #f4f4f4;
-    padding: 20px;
+    margin: 0;
+    padding: 0;
+    background: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('../../../Images/background.webp');
+    background-size: cover;
+    background-attachment: fixed;
+    background-repeat: no-repeat;
+    color: #fff;
 }
 
 .container {
     max-width: 1200px;
     margin: 0 auto;
     padding: 20px;
-    background-color: #fff;
+    background: rgba(0, 102, 51, 0.5);
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
 h1 {
     text-align: center;
     margin-bottom: 10px;
-    color: #333;
-    font-family: 'Open Sans', sans-serif;
-    font-size: 2em;
+    color: #fff;
+    font-family: 'Style Script', cursive;
+    font-size: 2.5em;
 }
 
 .instruction {
     text-align: center;
     margin-bottom: 30px;
     font-size: 1.3em;
-    color: #555;
+    color: #fff;
     font-family: 'Open Sans', sans-serif;
 }
 

--- a/Productions/DM Page de garde/Classe-3/Page-garde-classe-3.html
+++ b/Productions/DM Page de garde/Classe-3/Page-garde-classe-3.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Productions des élèves - Classe 3</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="../../../styles.css">
 </head>
 <body>
     <div class="container">

--- a/Productions/DM Page de garde/Classe-3/styles.css
+++ b/Productions/DM Page de garde/Classe-3/styles.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&family=Style+Script&display=swap');
 
 * {
     margin: 0;
@@ -8,31 +8,36 @@
 
 body {
     font-family: 'Roboto', sans-serif;
-    background-color: #f4f4f4;
-    padding: 20px;
+    margin: 0;
+    padding: 0;
+    background: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('../../../Images/background.webp');
+    background-size: cover;
+    background-attachment: fixed;
+    background-repeat: no-repeat;
+    color: #fff;
 }
 
 .container {
     max-width: 1200px;
     margin: 0 auto;
     padding: 20px;
-    background-color: #fff;
+    background: rgba(0, 102, 51, 0.5);
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
 h1 {
     text-align: center;
     margin-bottom: 10px;
-    color: #333;
-    font-family: 'Open Sans', sans-serif;
-    font-size: 2em;
+    color: #fff;
+    font-family: 'Style Script', cursive;
+    font-size: 2.5em;
 }
 
 .instruction {
     text-align: center;
     margin-bottom: 30px;
     font-size: 1.3em;
-    color: #555;
+    color: #fff;
     font-family: 'Open Sans', sans-serif;
 }
 


### PR DESCRIPTION
## Summary
- use homepage styling for all student gallery pages
- reference central `styles.css` from each gallery page
- update galleries' stylesheet to match homepage background and fonts

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852dfeb2fe4832d92a325d99cc9812b