### PR TITLE
Fix course links and correct 4e HTML

### DIFF
--- a/cours_4e.html
+++ b/cours_4e.html
@@ -22,7 +22,7 @@
                     <div class="dropdown-content">
                         <a href="cours_6e.html">6<sup>ème</sup></a>
                         <a href="cours_5e.html">5<sup>ème</sup></a>
-                        <a href="#">4<sup>ème</sup></a>
+                        <a href="cours_4e.html">4<sup>ème</sup></a>
                         <a href="cours_3e.html">3<sup>ème</sup></a>
                     </div>
                 </li>
@@ -98,8 +98,8 @@
             <article class="course-card">
                 <h3>Organisation et Gestion de Données</h3>
                 <ul>
-                    <li><a href="4eme/cours_4d1.html">D1. Proportionnalité</a><                    <li><a href="4eme/cours_4d2.html">D2. Statistiques</a></li>
-/li>
+                    <li><a href="4eme/cours_4d1.html">D1. Proportionnalité</a></li>
+                    <li><a href="4eme/cours_4d2.html">D2. Statistiques</a></li>
                     <li><a href="4eme/cours_4d3.html">D3. Grandeurs produits et grandeurs quotients</a></li>
                 </ul>
             </article>

--- a/cours_5e.html
+++ b/cours_5e.html
@@ -21,7 +21,7 @@
                     <a href="#maths" class="dropbtn">Mathématiques</a>
                     <div class="dropdown-content">
                         <a href="cours_6e.html">6<sup>ème</sup></a>
-                        <a href="#">5<sup>ème</sup></a>
+                        <a href="cours_5e.html">5<sup>ème</sup></a>
                         <a href="cours_4e.html">4<sup>ème</sup></a>
                         <a href="cours_3e.html">3<sup>ème</sup></a>
                     </div>

--- a/cours_6e.html
+++ b/cours_6e.html
@@ -20,7 +20,7 @@
                 <li class="dropdown">
                     <a href="#maths" class="dropbtn">Mathématiques</a>
                     <div class="dropdown-content">
-                        <a href="#">6<sup>ème</sup></a>
+                        <a href="cours_6e.html">6<sup>ème</sup></a>
                         <a href="cours_5e.html">5<sup>ème</sup></a>
                         <a href="cours_4e.html">4<sup>ème</sup></a>
                         <a href="cours_3e.html">3<sup>ème</sup></a>

--- a/index.html
+++ b/index.html
@@ -17,9 +17,9 @@
                 <li class="dropdown">
                     <a href="#maths" class="dropbtn">Mathématiques</a>
                     <div class="dropdown-content">
-                        <a href="#maths-6e">6e</a>
-                        <a href="#maths-5e">5e</a>
-                        <a href="#maths-4e">4e</a>
+                        <a href="cours_6e.html">6e</a>
+                        <a href="cours_5e.html">5e</a>
+                        <a href="cours_4e.html">4e</a>
                         <a href="#maths-3e">3e</a>
                     </div>
                 </li>


### PR DESCRIPTION
## Summary
- link `cours_6e.html`, `cours_5e.html`, and `cours_4e.html` from the main menu
- fix the dropdown on each course page to link to itself
- correct malformed list in `cours_4e.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6852e44a6158832db95f6c0577ac09ea