### PR TITLE
Improve popup image display proportions

### DIFF
--- a/Productions/DM Page de garde/Classe-1/Page-garde-classe-1.html
+++ b/Productions/DM Page de garde/Classe-1/Page-garde-classe-1.html
@@ -162,13 +162,19 @@
     <script>
         // Ouvre l'image en plein écran
         function openImage(src) {
-            document.getElementById("popup").style.display = "block";
-            document.getElementById("popupImage").src = src;
+            const popup = document.getElementById("popup");
+            const popupImage = document.getElementById("popupImage");
+            popupImage.src = src;
+            popup.style.display = "flex";
+            document.body.style.overflow = "hidden";
         }
 
         // Ferme l'image en plein écran
         function closeImage() {
-            document.getElementById("popup").style.display = "none";
+            const popup = document.getElementById("popup");
+            popup.style.display = "none";
+            document.getElementById("popupImage").src = "";
+            document.body.style.overflow = "";
         }
     </script>
 </body>

--- a/Productions/DM Page de garde/Classe-1/styles.css
+++ b/Productions/DM Page de garde/Classe-1/styles.css
@@ -93,14 +93,19 @@ h1 {
     top: 0;
     width: 100%;
     height: 100%;
+    padding: 20px;
     background-color: rgba(0, 0, 0, 0.8);
+    align-items: center;
+    justify-content: center;
 }
 
 .popup-content {
-    margin: auto;
-    display: block;
-    max-width: 80%;
-    max-height: 80%;
+    width: auto;
+    height: auto;
+    max-width: 90vw;
+    max-height: 90vh;
+    object-fit: contain;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
 }
 
 .close {

--- a/Productions/DM Page de garde/Classe-2/Page-garde-classe-2.html
+++ b/Productions/DM Page de garde/Classe-2/Page-garde-classe-2.html
@@ -158,13 +158,19 @@
     <script>
         // Ouvre l'image en plein écran
         function openImage(src) {
-            document.getElementById("popup").style.display = "block";
-            document.getElementById("popupImage").src = src;
+            const popup = document.getElementById("popup");
+            const popupImage = document.getElementById("popupImage");
+            popupImage.src = src;
+            popup.style.display = "flex";
+            document.body.style.overflow = "hidden";
         }
 
         // Ferme l'image en plein écran
         function closeImage() {
-            document.getElementById("popup").style.display = "none";
+            const popup = document.getElementById("popup");
+            popup.style.display = "none";
+            document.getElementById("popupImage").src = "";
+            document.body.style.overflow = "";
         }
     </script>
 </body>

--- a/Productions/DM Page de garde/Classe-2/styles.css
+++ b/Productions/DM Page de garde/Classe-2/styles.css
@@ -93,14 +93,19 @@ h1 {
     top: 0;
     width: 100%;
     height: 100%;
+    padding: 20px;
     background-color: rgba(0, 0, 0, 0.8);
+    align-items: center;
+    justify-content: center;
 }
 
 .popup-content {
-    margin: auto;
-    display: block;
-    max-width: 80%;
-    max-height: 80%;
+    width: auto;
+    height: auto;
+    max-width: 90vw;
+    max-height: 90vh;
+    object-fit: contain;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
 }
 
 .close {

--- a/Productions/DM Page de garde/Classe-3/Page-garde-classe-3.html
+++ b/Productions/DM Page de garde/Classe-3/Page-garde-classe-3.html
@@ -158,13 +158,19 @@
     <script>
         // Ouvre l'image en plein écran
         function openImage(src) {
-            document.getElementById("popup").style.display = "block";
-            document.getElementById("popupImage").src = src;
+            const popup = document.getElementById("popup");
+            const popupImage = document.getElementById("popupImage");
+            popupImage.src = src;
+            popup.style.display = "flex";
+            document.body.style.overflow = "hidden";
         }
 
         // Ferme l'image en plein écran
         function closeImage() {
-            document.getElementById("popup").style.display = "none";
+            const popup = document.getElementById("popup");
+            popup.style.display = "none";
+            document.getElementById("popupImage").src = "";
+            document.body.style.overflow = "";
         }
     </script>
 </body>

--- a/Productions/DM Page de garde/Classe-3/styles.css
+++ b/Productions/DM Page de garde/Classe-3/styles.css
@@ -93,14 +93,19 @@ h1 {
     top: 0;
     width: 100%;
     height: 100%;
+    padding: 20px;
     background-color: rgba(0, 0, 0, 0.8);
+    align-items: center;
+    justify-content: center;
 }
 
 .popup-content {
-    margin: auto;
-    display: block;
-    max-width: 80%;
-    max-height: 80%;
+    width: auto;
+    height: auto;
+    max-width: 90vw;
+    max-height: 90vh;
+    object-fit: contain;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
 }
 
 .close {


### PR DESCRIPTION
## Summary
- center the zoom popup and constrain enlarged images to the viewport to avoid stretching
- prevent background scrolling while the popup is open for a stable layout across pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d06b19b220832d995f21bd42422bbc